### PR TITLE
unify hash macro by renaming it to `construct_hash`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ matrix:
   allow_failures:
     - rust: nightly
 script:
-  - cargo test -p ethereum-types --no-default-futures
-  - cargo test -p tests
+  - cargo test -p ethereum-types --no-default-features --release
+  - cargo test -p tests --release
 env:
   - RUST_LOG=quickcheck

--- a/ethereum-types/src/hash.rs
+++ b/ethereum-types/src/hash.rs
@@ -1,15 +1,15 @@
 use U256;
 
-impl_hash!(H32, 4);
-impl_hash!(H64, 8);
-impl_hash!(H128, 16);
-impl_hash!(H160, 20);
-impl_hash!(H256, 32);
-impl_hash!(H264, 33);
-impl_hash!(H512, 64);
-impl_hash!(H520, 65);
-impl_hash!(H1024, 128);
-impl_hash!(H2048, 256);
+construct_hash!(H32, 4);
+construct_hash!(H64, 8);
+construct_hash!(H128, 16);
+construct_hash!(H160, 20);
+construct_hash!(H256, 32);
+construct_hash!(H264, 33);
+construct_hash!(H512, 64);
+construct_hash!(H520, 65);
+construct_hash!(H1024, 128);
+construct_hash!(H2048, 256);
 
 impl From<U256> for H256 {
 	fn from(value: U256) -> H256 {

--- a/fixed-hash/src/hash.rs
+++ b/fixed-hash/src/hash.rs
@@ -16,7 +16,7 @@ pub fn clean_0x(s: &str) -> &str {
 }
 
 #[macro_export]
-macro_rules! impl_hash {
+macro_rules! construct_hash {
 	($from: ident, $size: expr) => {
 		#[repr(C)]
 		/// Unformatted binary data of fixed length.

--- a/uint/Cargo.toml
+++ b/uint/Cargo.toml
@@ -16,6 +16,9 @@ byteorder = { version = "1", default-features = false }
 heapsize = { version = "0.4", optional = true }
 rustc-hex = { version = "1.0", optional = true }
 
+[dev-dependencies]
+crunchy = "0.1.5"
+
 [features]
 std = ["rustc-hex"]
 heapsizeof = ["heapsize"]

--- a/uint/examples/modular.rs
+++ b/uint/examples/modular.rs
@@ -6,9 +6,16 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#[cfg(feature="std")]
+extern crate core;
+
+#[macro_use]
+extern crate crunchy;
+
+#[macro_use]
 extern crate uint;
 
-use uint::U256;
+construct_uint!(U256, 32);
 
 fn main() {
 	// Example modular arithmetic using bigint U256 primitives


### PR DESCRIPTION
also fixed one of the examples