### PR TITLE
Add 0x when printing hex values.

### DIFF
--- a/ethereum-types/src/hash.rs
+++ b/ethereum-types/src/hash.rs
@@ -1,4 +1,4 @@
-use U256;
+use {U128, U256, U512};
 
 #[cfg(feature="serialize")]
 use serde::{Serialize, Serializer, Deserialize, Deserializer};
@@ -16,34 +16,7 @@ construct_hash!(H512, 64);
 construct_hash!(H520, 65);
 construct_hash!(H1024, 128);
 
-impl From<U256> for H256 {
-	fn from(value: U256) -> H256 {
-		let mut ret = H256::new();
-		value.to_big_endian(&mut ret);
-		ret
-	}
-}
-
-impl<'a> From<&'a U256> for H256 {
-	fn from(value: &'a U256) -> H256 {
-		let mut ret: H256 = H256::new();
-		value.to_big_endian(&mut ret);
-		ret
-	}
-}
-
-impl From<H256> for U256 {
-	fn from(value: H256) -> U256 {
-		U256::from(&value)
-	}
-}
-
-impl<'a> From<&'a H256> for U256 {
-	fn from(value: &'a H256) -> U256 {
-		U256::from(value.as_ref() as &[u8])
-	}
-}
-
+#[deprecated]
 impl From<H256> for H160 {
 	fn from(value: H256) -> H160 {
 		let mut ret = H160::new();
@@ -52,6 +25,7 @@ impl From<H256> for H160 {
 	}
 }
 
+#[deprecated]
 impl From<H256> for H64 {
 	fn from(value: H256) -> H64 {
 		let mut ret = H64::new();
@@ -75,6 +49,42 @@ impl<'a> From<&'a H160> for H256 {
 		ret
 	}
 }
+
+macro_rules! impl_uint_conversions {
+	($hash: ident, $uint: ident) => {
+		impl From<$uint> for $hash {
+			fn from(value: $uint) -> Self {
+				let mut ret = $hash::new();
+				value.to_big_endian(&mut ret);
+				ret
+			}
+		}
+
+		impl<'a> From<&'a $uint> for $hash {
+			fn from(value: &'a $uint) -> Self {
+				let mut ret = $hash::new();
+				value.to_big_endian(&mut ret);
+				ret
+			}
+		}
+
+		impl From<$hash> for $uint {
+			fn from(value: $hash) -> Self {
+				Self::from(&value)
+			}
+		}
+
+		impl<'a> From<&'a $hash> for $uint {
+			fn from(value: &'a $hash) -> Self {
+				Self::from(value.as_ref() as &[u8])
+			}
+		}
+	}
+}
+
+impl_uint_conversions!(H128, U128);
+impl_uint_conversions!(H256, U256);
+impl_uint_conversions!(H512, U512);
 
 macro_rules! impl_serde {
 	($name: ident, $len: expr) => {

--- a/ethereum-types/src/hash.rs
+++ b/ethereum-types/src/hash.rs
@@ -1,4 +1,4 @@
-use {U128, U256, U512};
+use {U64, U128, U256, U512, U1024};
 
 #[cfg(feature="serialize")]
 use serde::{Serialize, Serializer, Deserialize, Deserializer};
@@ -82,9 +82,11 @@ macro_rules! impl_uint_conversions {
 	}
 }
 
+impl_uint_conversions!(H64, U64);
 impl_uint_conversions!(H128, U128);
 impl_uint_conversions!(H256, U256);
 impl_uint_conversions!(H512, U512);
+impl_uint_conversions!(H1024, U1024);
 
 macro_rules! impl_serde {
 	($name: ident, $len: expr) => {

--- a/ethereum-types/src/lib.rs
+++ b/ethereum-types/src/lib.rs
@@ -20,7 +20,7 @@ extern crate serde;
 mod hash;
 mod uint;
 
-pub use uint::{U128, U256, U512};
+pub use uint::{U64, U128, U256, U512, U1024};
 pub use hash::{H32, H64, H128, H160, H256, H264, H512, H520, H1024};
 pub use ethbloom::{Bloom, BloomRef, Input as BloomInput};
 pub use fixed_hash::clean_0x;

--- a/ethereum-types/src/uint.rs
+++ b/ethereum-types/src/uint.rs
@@ -4,9 +4,11 @@ use serde::{Serialize, Serializer, Deserialize, Deserializer};
 #[cfg(feature="serialize")]
 use ethereum_types_serialize;
 
+construct_uint!(U64, 1);
 construct_uint!(U128, 2);
 construct_uint!(U256, 4);
 construct_uint!(U512, 8);
+construct_uint!(U1024, 16);
 
 impl U256 {
 	/// Multiplies two 256-bit integers to produce full 512-bit integer

--- a/fixed-hash/src/hash.rs
+++ b/fixed-hash/src/hash.rs
@@ -119,15 +119,14 @@ macro_rules! construct_hash {
 
 		impl ::core::fmt::Debug for $from {
 			fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
-				for i in &self.0[..] {
-					write!(f, "{:02x}", i)?;
-				}
-				Ok(())
+				write!(f, "0x")?;
+				::core::fmt::LowerHex::fmt(self, f)
 			}
 		}
 
 		impl ::core::fmt::Display for $from {
 			fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+				write!(f, "0x")?;
 				for i in &self.0[0..2] {
 					write!(f, "{:02x}", i)?;
 				}
@@ -141,7 +140,10 @@ macro_rules! construct_hash {
 
 		impl ::core::fmt::LowerHex for $from {
 			fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
-				::core::fmt::Debug::fmt(self, f)
+				for i in &self.0[..] {
+					write!(f, "{:02x}", i)?;
+				}
+				Ok(())
 			}
 		}
 

--- a/tests/src/hash_tests.rs
+++ b/tests/src/hash_tests.rs
@@ -1,0 +1,20 @@
+use ethereum_types::{U128, H128};
+
+#[test]
+fn should_format_and_debug_correctly() {
+    let test = |x: usize, hex: &'static str, display: &'static str| {
+		let hash = H128::from(U128::from(x));
+        assert_eq!(format!("{}", hash), format!("0x{}", display));
+        assert_eq!(format!("{:?}", hash), format!("0x{}", hex));
+        assert_eq!(format!("{:x}", hash), hex);
+    };
+
+    test(0x1, "00000000000000000000000000000001", "0000…0001");
+    test(0xf, "0000000000000000000000000000000f", "0000…000f");
+    test(0x10, "00000000000000000000000000000010", "0000…0010");
+    test(0xff, "000000000000000000000000000000ff", "0000…00ff");
+    test(0x100, "00000000000000000000000000000100", "0000…0100");
+    test(0xfff, "00000000000000000000000000000fff", "0000…0fff");
+    test(0x1000, "00000000000000000000000000001000", "0000…1000");
+}
+

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -14,6 +14,8 @@ extern crate quickcheck;
 extern crate serde_json;
 
 #[cfg(test)]
+pub mod hash_tests;
+#[cfg(test)]
 pub mod uint_tests;
 #[cfg(test)]
 pub mod serialization;

--- a/tests/src/uint_tests.rs
+++ b/tests/src/uint_tests.rs
@@ -254,8 +254,9 @@ fn uint256_pow_overflow_panic() {
 
 #[test]
 fn should_format_and_debug_correctly() {
-    let test = |x: usize, hex: &'static str, dbg: &'static str| {
-        assert_eq!(format!("{:?}", U256::from(x)), dbg);
+    let test = |x: usize, hex: &'static str, display: &'static str| {
+        assert_eq!(format!("{}", U256::from(x)), display);
+        assert_eq!(format!("{:?}", U256::from(x)), format!("0x{}", hex));
         assert_eq!(format!("{:x}", U256::from(x)), hex);
     };
 

--- a/uint/src/uint.rs
+++ b/uint/src/uint.rs
@@ -1252,7 +1252,8 @@ macro_rules! impl_std_for_uint {
 	($name: ident, $n_words: tt) => {
 		impl ::core::fmt::Debug for $name {
 			fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
-				::core::fmt::Display::fmt(self, f)
+				write!(f, "0x")?;
+				::core::fmt::LowerHex::fmt(self, f)
 			}
 		}
 


### PR DESCRIPTION
Currently:
```rust
format!("{}", H128::from(0xf)) == "0000…000f"
format!("{:?}", H128::from(0xf)) == "0000000000000000000000000000000f"
format!("{:x}", H128::from(0xf)) == "0000000000000000000000000000000f"

format!("{}", U128::from(0xf)) == "15"
format!("{:?}", U128::from(0xf)) == "15"
format!("{:x}", U128::from(0xf)) == "f"
```

This PR proposes to prepend `0x` everytime a hex number is displayed (unless it's explicitly using `LowerHex` formatting). Also it changes `Debug` of uint to use hex. After:
```rust
format!("{}", H128::from(0xf)) == "0x0000…000f"
format!("{:?}", H128::from(0xf)) == "0x0000000000000000000000000000000f"
format!("{:x}", H128::from(0xf)) == "0000000000000000000000000000000f"

format!("{}", U128::from(0xf)) == "15"
format!("{:?}", U128::from(0xf)) == "0xf"
format!("{:x}", U128::from(0xf)) == "f"
```

Make `Debug` implementations look nicer for developers. It's also aligned with serialization format.
