### PR TITLE
Fix missing serde impls for uints.

### DIFF
--- a/ethereum-types/src/hash.rs
+++ b/ethereum-types/src/hash.rs
@@ -6,47 +6,24 @@ use serde::{Serialize, Serializer, Deserialize, Deserializer};
 #[cfg(feature="serialize")]
 use ethereum_types_serialize;
 
-construct_hash!(H32, 4);
-construct_hash!(H64, 8);
-construct_hash!(H128, 16);
-construct_hash!(H160, 20);
-construct_hash!(H256, 32);
-construct_hash!(H264, 33);
-construct_hash!(H512, 64);
-construct_hash!(H520, 65);
-construct_hash!(H1024, 128);
+macro_rules! impl_serde {
+	($name: ident, $len: expr) => {
+		#[cfg(feature="serialize")]
+		impl Serialize for $name {
+			fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error> where S: Serializer {
+				let mut slice = [0u8; 2 + 2 * $len];
+				ethereum_types_serialize::serialize(&mut slice, &self.0, serializer)
+			}
+		}
 
-#[deprecated]
-impl From<H256> for H160 {
-	fn from(value: H256) -> H160 {
-		let mut ret = H160::new();
-		ret.0.copy_from_slice(&value[12..32]);
-		ret
-	}
-}
-
-#[deprecated]
-impl From<H256> for H64 {
-	fn from(value: H256) -> H64 {
-		let mut ret = H64::new();
-		ret.0.copy_from_slice(&value[20..28]);
-		ret
-	}
-}
-
-impl From<H160> for H256 {
-	fn from(value: H160) -> H256 {
-		let mut ret = H256::new();
-		ret.0[12..32].copy_from_slice(&value);
-		ret
-	}
-}
-
-impl<'a> From<&'a H160> for H256 {
-	fn from(value: &'a H160) -> H256 {
-		let mut ret = H256::new();
-		ret.0[12..32].copy_from_slice(value);
-		ret
+		#[cfg(feature="serialize")]
+		impl<'de> Deserialize<'de> for $name {
+			fn deserialize<D>(deserializer: D) -> Result<Self, D::Error> where D: Deserializer<'de> {
+				let mut bytes = [0u8; $len];
+				ethereum_types_serialize::deserialize_check_len(deserializer, ethereum_types_serialize::ExpectedLen::Exact(&mut bytes))?;
+				Ok($name(bytes))
+			}
+		}
 	}
 }
 
@@ -82,33 +59,6 @@ macro_rules! impl_uint_conversions {
 	}
 }
 
-impl_uint_conversions!(H64, U64);
-impl_uint_conversions!(H128, U128);
-impl_uint_conversions!(H256, U256);
-impl_uint_conversions!(H512, U512);
-impl_uint_conversions!(H1024, U1024);
-
-macro_rules! impl_serde {
-	($name: ident, $len: expr) => {
-		#[cfg(feature="serialize")]
-		impl Serialize for $name {
-			fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error> where S: Serializer {
-				let mut slice = [0u8; 2 + 2 * $len];
-				ethereum_types_serialize::serialize(&mut slice, &self.0, serializer)
-			}
-		}
-
-		#[cfg(feature="serialize")]
-		impl<'de> Deserialize<'de> for $name {
-			fn deserialize<D>(deserializer: D) -> Result<Self, D::Error> where D: Deserializer<'de> {
-				let mut bytes = [0u8; $len];
-				ethereum_types_serialize::deserialize_check_len(deserializer, ethereum_types_serialize::ExpectedLen::Exact(&mut bytes))?;
-				Ok($name(bytes))
-			}
-		}
-	}
-}
-
 impl_serde!(H32, 4);
 impl_serde!(H64, 8);
 impl_serde!(H128, 16);
@@ -118,3 +68,53 @@ impl_serde!(H264, 33);
 impl_serde!(H512, 64);
 impl_serde!(H520, 65);
 impl_serde!(H1024, 128);
+
+construct_hash!(H32, 4);
+construct_hash!(H64, 8);
+construct_hash!(H128, 16);
+construct_hash!(H160, 20);
+construct_hash!(H256, 32);
+construct_hash!(H264, 33);
+construct_hash!(H512, 64);
+construct_hash!(H520, 65);
+construct_hash!(H1024, 128);
+
+impl_uint_conversions!(H64, U64);
+impl_uint_conversions!(H128, U128);
+impl_uint_conversions!(H256, U256);
+impl_uint_conversions!(H512, U512);
+impl_uint_conversions!(H1024, U1024);
+
+#[deprecated]
+impl From<H256> for H160 {
+	fn from(value: H256) -> H160 {
+		let mut ret = H160::new();
+		ret.0.copy_from_slice(&value[12..32]);
+		ret
+	}
+}
+
+#[deprecated]
+impl From<H256> for H64 {
+	fn from(value: H256) -> H64 {
+		let mut ret = H64::new();
+		ret.0.copy_from_slice(&value[20..28]);
+		ret
+	}
+}
+
+impl From<H160> for H256 {
+	fn from(value: H160) -> H256 {
+		let mut ret = H256::new();
+		ret.0[12..32].copy_from_slice(&value);
+		ret
+	}
+}
+
+impl<'a> From<&'a H160> for H256 {
+	fn from(value: &'a H160) -> H256 {
+		let mut ret = H256::new();
+		ret.0[12..32].copy_from_slice(value);
+		ret
+	}
+}

--- a/ethereum-types/src/uint.rs
+++ b/ethereum-types/src/uint.rs
@@ -4,11 +4,40 @@ use serde::{Serialize, Serializer, Deserialize, Deserializer};
 #[cfg(feature="serialize")]
 use ethereum_types_serialize;
 
+macro_rules! impl_serde {
+	($name: ident, $len: expr) => {
+		#[cfg(feature="serialize")]
+		impl Serialize for $name {
+			fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error> where S: Serializer {
+				let mut slice = [0u8; 2 + 2 * $len * 8];
+				let mut bytes = [0u8; $len * 8];
+				self.to_big_endian(&mut bytes);
+				ethereum_types_serialize::serialize_uint(&mut slice, &bytes, serializer)
+			}
+		}
+
+		#[cfg(feature="serialize")]
+		impl<'de> Deserialize<'de> for $name {
+			fn deserialize<D>(deserializer: D) -> Result<Self, D::Error> where D: Deserializer<'de> {
+				let mut bytes = [0u8; $len * 8];
+				let wrote = ethereum_types_serialize::deserialize_check_len(deserializer, ethereum_types_serialize::ExpectedLen::Between(0, &mut bytes))?;
+				Ok(bytes[0..wrote].into())
+			}
+		}
+	}
+}
+
 construct_uint!(U64, 1);
 construct_uint!(U128, 2);
 construct_uint!(U256, 4);
 construct_uint!(U512, 8);
 construct_uint!(U1024, 16);
+
+impl_serde!(U64, 1);
+impl_serde!(U128, 2);
+impl_serde!(U256, 4);
+impl_serde!(U512, 8);
+impl_serde!(U1024, 16);
 
 impl U256 {
 	/// Multiplies two 256-bit integers to produce full 512-bit integer
@@ -330,30 +359,3 @@ impl From<U512> for [u8; 64] {
 		arr
 	}
 }
-
-macro_rules! impl_serde {
-	($name: ident, $len: expr) => {
-		#[cfg(feature="serialize")]
-		impl Serialize for $name {
-			fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error> where S: Serializer {
-				let mut slice = [0u8; 2 + 2 * $len * 8];
-				let mut bytes = [0u8; $len * 8];
-				self.to_big_endian(&mut bytes);
-				ethereum_types_serialize::serialize_uint(&mut slice, &bytes, serializer)
-			}
-		}
-
-		#[cfg(feature="serialize")]
-		impl<'de> Deserialize<'de> for $name {
-			fn deserialize<D>(deserializer: D) -> Result<Self, D::Error> where D: Deserializer<'de> {
-				let mut bytes = [0u8; $len * 8];
-				let wrote = ethereum_types_serialize::deserialize_check_len(deserializer, ethereum_types_serialize::ExpectedLen::Between(0, &mut bytes))?;
-				Ok(bytes[0..wrote].into())
-			}
-		}
-	}
-}
-
-impl_serde!(U128, 2);
-impl_serde!(U256, 4);
-impl_serde!(U512, 8);


### PR DESCRIPTION
Also re-organize the fiels so that `impl_*` macros are next to each other.