### PR TITLE
Don't use libc with wasm32-unknown-unknown

### DIFF
--- a/fixed-hash/Cargo.toml
+++ b/fixed-hash/Cargo.toml
@@ -8,10 +8,12 @@ description = "Fixed-size hashes"
 
 [dependencies]
 heapsize = { version = "0.4", optional = true }
-libc = { version = "0.2", optional = true, default-features = false }
 rand = { version = "0.4", optional = true }
 rustc-hex = { version = "1.0", optional = true }
 quickcheck = { version = "0.6", optional = true }
+
+[target.'cfg(not(target_os = "unknown"))'.dependencies]
+libc = { version = "0.2", optional = true, default-features = false }
 
 [features]
 default = ["libc"]

--- a/fixed-hash/src/hash.rs
+++ b/fixed-hash/src/hash.rs
@@ -418,7 +418,7 @@ macro_rules! impl_std_for_hash_internals {
 	($from: ident, $size: tt) => {}
 }
 
-#[cfg(feature="libc")]
+#[cfg(all(feature="libc", not(target_os = "unknown")))]
 #[macro_export]
 #[doc(hidden)]
 macro_rules! impl_heapsize_for_hash {
@@ -431,7 +431,7 @@ macro_rules! impl_heapsize_for_hash {
 	}
 }
 
-#[cfg(feature="libc")]
+#[cfg(all(feature="libc", not(target_os = "unknown")))]
 #[macro_export]
 #[doc(hidden)]
 macro_rules! impl_libc_for_hash {
@@ -453,7 +453,7 @@ macro_rules! impl_libc_for_hash {
 	}
 }
 
-#[cfg(not(feature="libc"))]
+#[cfg(any(not(feature="libc"), target_os = "unknown"))]
 #[macro_export]
 #[doc(hidden)]
 macro_rules! impl_libc_for_hash {

--- a/fixed-hash/src/lib.rs
+++ b/fixed-hash/src/lib.rs
@@ -8,7 +8,7 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
-#[cfg(feature="libc")]
+#[cfg(all(feature="libc", not(target_os = "unknown")))]
 #[doc(hidden)]
 pub extern crate libc;
 


### PR DESCRIPTION
Makes `ethbloom` compile for `wasm32-unknown-unknown`.