### PR TITLE
Prefix `0x` for lower hex with alternate flag

### DIFF
--- a/tests/src/uint_tests.rs
+++ b/tests/src/uint_tests.rs
@@ -258,6 +258,7 @@ fn should_format_and_debug_correctly() {
 		assert_eq!(format!("{}", U256::from(x)), display);
 		assert_eq!(format!("{:?}", U256::from(x)), format!("0x{}", hex));
 		assert_eq!(format!("{:x}", U256::from(x)), hex);
+		assert_eq!(format!("{:#x}", U256::from(x)), format!("0x{}", hex));
 	};
 
 	test(0x1, "1", "1");

--- a/uint/src/uint.rs
+++ b/uint/src/uint.rs
@@ -1261,8 +1261,7 @@ macro_rules! impl_std_for_uint {
 	($name: ident, $n_words: tt) => {
 		impl ::core::fmt::Debug for $name {
 			fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
-				write!(f, "0x")?;
-				::core::fmt::LowerHex::fmt(self, f)
+				write!(f, "{:#x}", self)
 			}
 		}
 

--- a/uint/src/uint.rs
+++ b/uint/src/uint.rs
@@ -1304,6 +1304,9 @@ macro_rules! impl_std_for_uint {
 		impl ::core::fmt::LowerHex for $name {
 			fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
 				let &$name(ref data) = self;
+				if f.alternate() {
+					write!(f, "0x");
+				}
 				// special case.
 				if self.is_zero() {
 					return write!(f, "0");


### PR DESCRIPTION
Should fix https://github.com/paritytech/parity/issues/8393. As per https://doc.rust-lang.org/std/fmt/trait.LowerHex.html