### PR TITLE
Increment `patch` for uint and ethereum-types

### DIFF
--- a/ethereum-types/Cargo.toml
+++ b/ethereum-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethereum-types"
-version = "0.3.1"
+version = "0.3.2"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 homepage = "https://github.com/paritytech/primitives"
@@ -11,7 +11,7 @@ build = "build.rs"
 rustc_version = "0.2"
 
 [dependencies]
-uint = { path = "../uint", version = "0.2" }
+uint = { path = "../uint", version = "0.2.1" }
 fixed-hash = { path = "../fixed-hash", version = "0.2" }
 ethbloom = { path = "../ethbloom", version = "0.5.0" }
 crunchy = "0.1.5"

--- a/uint/Cargo.toml
+++ b/uint/Cargo.toml
@@ -4,7 +4,7 @@ homepage = "http://parity.io"
 repository = "https://github.com/paritytech/primitives"
 license = "MIT/Apache-2.0"
 name = "uint"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 build = "build.rs"
 


### PR DESCRIPTION
Probably should have bumped the versions as part of the original PR #33? 

Next need to update parity to use this, in order to fix https://github.com/paritytech/parity/issues/8393