### PR TITLE
Prefix '0x' for lower hex with alternate flag.

### DIFF
--- a/fixed-hash/src/hash.rs
+++ b/fixed-hash/src/hash.rs
@@ -133,8 +133,7 @@ macro_rules! construct_hash {
 
 		impl ::core::fmt::Debug for $from {
 			fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
-				write!(f, "0x")?;
-				::core::fmt::LowerHex::fmt(self, f)
+				write!(f, "{:#x}", self)
 			}
 		}
 
@@ -154,6 +153,9 @@ macro_rules! construct_hash {
 
 		impl ::core::fmt::LowerHex for $from {
 			fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+				if f.alternate() {
+					write!(f, "0x");
+				}
 				for i in &self.0[..] {
 					write!(f, "{:02x}", i)?;
 				}

--- a/tests/src/hash_tests.rs
+++ b/tests/src/hash_tests.rs
@@ -7,6 +7,7 @@ fn should_format_and_debug_correctly() {
         assert_eq!(format!("{}", hash), format!("0x{}", display));
         assert_eq!(format!("{:?}", hash), format!("0x{}", hex));
         assert_eq!(format!("{:x}", hash), hex);
+        assert_eq!(format!("{:#x}", hash), format!("0x{}", hex));
     };
 
     test(0x1, "00000000000000000000000000000001", "0000…0001");


### PR DESCRIPTION
I'm not sure if it was a bug, too, as same as [Merged PR-33](https://github.com/paritytech/primitives/pull/33).