### PR TITLE
Nits

### DIFF
--- a/serialize/src/lib.rs
+++ b/serialize/src/lib.rs
@@ -8,8 +8,8 @@ static CHARS: &'static[u8] = b"0123456789abcdef";
 fn to_hex<'a>(v: &'a mut [u8], bytes: &[u8], skip_leading_zero: bool) -> &'a str {
 	assert!(v.len() > 1 + bytes.len() * 2);
 
-	v[0] = '0' as u8;
-	v[1] = 'x' as u8;
+	v[0] = b'0';
+	v[1] = b'x';
 
 	let mut idx = 2;
 	let first_nibble = bytes[0] >> 4;

--- a/uint/src/uint.rs
+++ b/uint/src/uint.rs
@@ -603,7 +603,7 @@ pub fn mul_u32(a: (u64, u64), b: u64, carry: u64) -> (u64, u64) {
 #[inline(always)]
 #[doc(hidden)]
 pub fn split(a: u64) -> (u64, u64) {
-	(a >> 32, a & 0xFFFFFFFF)
+	(a >> 32, a & 0xFFFF_FFFF)
 }
 
 #[macro_export]


### PR DESCRIPTION
* Use b`x` instead of `x` as u8 -> no casting required
* Use more human-friendly repr of hex value