### PR TITLE
ethereum-types `make it work in no_std`

### DIFF
--- a/ethbloom/Cargo.toml
+++ b/ethbloom/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/paritytech/primitives"
 [dependencies]
 tiny-keccak = "1.4"
 crunchy = { version = "0.1.6", features = ["limit_256"] }
-fixed-hash = { version = "0.2.1", path = "../fixed-hash" }
+fixed-hash = { version = "0.2.1", path = "../fixed-hash", default-features = false }
 ethereum-types-serialize = { version = "0.2.1", path = "../serialize", optional = true }
 serde = { version = "1.0", optional = true }
 

--- a/ethbloom/src/lib.rs
+++ b/ethbloom/src/lib.rs
@@ -47,8 +47,11 @@ extern crate serde;
 #[cfg(feature="serialize")]
 use serde::{Serialize, Serializer, Deserialize, Deserializer};
 
-use core::{ops, mem, str};
+use core::{ops, mem};
 use tiny_keccak::keccak256;
+
+#[cfg(feature="std")]
+use core::str;
 
 // 3 according to yellowpaper
 const BLOOM_BITS: u32 = 3;

--- a/ethereum-types/Cargo.toml
+++ b/ethereum-types/Cargo.toml
@@ -11,12 +11,12 @@ build = "build.rs"
 rustc_version = "0.2"
 
 [dependencies]
-uint = { path = "../uint", version = "0.2.1" }
-fixed-hash = { path = "../fixed-hash", version = "0.2" }
-ethbloom = { path = "../ethbloom", version = "0.5.0" }
 crunchy = "0.1.5"
+ethbloom = { path = "../ethbloom", version = "0.5.0", default-features = false }
 ethereum-types-serialize = { version = "0.2.1", path = "../serialize", optional = true }
+fixed-hash = { path = "../fixed-hash", version = "0.2" }
 serde = { version = "1.0", optional = true }
+uint = { path = "../uint", version = "0.2.1", default-features = false }
 
 [features]
 default = ["std", "heapsizeof", "serialize"]

--- a/fixed-hash/src/hash.rs
+++ b/fixed-hash/src/hash.rs
@@ -319,7 +319,7 @@ macro_rules! construct_hash {
 	}
 }
 
-#[cfg(feature="heapsizeof")]
+#[cfg(all(feature="heapsizeof", feature="libc", not(target_os = "unknown")))]
 #[macro_export]
 #[doc(hidden)]
 macro_rules! impl_heapsize_for_hash {
@@ -332,7 +332,7 @@ macro_rules! impl_heapsize_for_hash {
 	}
 }
 
-#[cfg(not(feature="heapsizeof"))]
+#[cfg(any(not(feature="heapsizeof"), not(feature="libc"), target_os = "unknown"))]
 #[macro_export]
 #[doc(hidden)]
 macro_rules! impl_heapsize_for_hash {
@@ -423,19 +423,6 @@ macro_rules! impl_std_for_hash_internals {
 #[doc(hidden)]
 macro_rules! impl_std_for_hash_internals {
 	($from: ident, $size: tt) => {}
-}
-
-#[cfg(all(feature="libc", not(target_os = "unknown")))]
-#[macro_export]
-#[doc(hidden)]
-macro_rules! impl_heapsize_for_hash {
-	($name: ident) => {
-		impl $crate::heapsize::HeapSizeOf for $name {
-			fn heap_size_of_children(&self) -> usize {
-				0
-			}
-		}
-	}
 }
 
 #[cfg(all(feature="libc", not(target_os = "unknown")))]


### PR DESCRIPTION
This PR depends on #41 

## Tested by 
```rustc
// main.rs
#![feature(lang_items, start, panic_implementation)]
#![no_std]

extern crate libc;
extern crate ethereum_types;

use ethereum_types::{Address, Public, Secret, Signature};

#[start]
fn start(_argc: isize, _argv: *const *const u8) -> isize {
    0
}

#[lang = "eh_personality"]
#[no_mangle]
pub extern "C" fn rust_eh_personality() {}

#[panic_implementation]
fn panic(_info: &core::panic::PanicInfo) -> ! {
    unsafe {
        libc::abort();
    }
}
```
```
// Cargo.toml
[dependencies]
libc = { version = "0.2.42", default-features = false }
ethereum-types = { git = "https://github.com/niklasad1/primitives", default-features = false, branch = "ethereum-types/no-std" }
```
## Output
```bash
no_std git:(master) ✗ cargo build
   Compiling semver-parser v0.7.0
   Compiling crunchy v0.1.6
   Compiling libc v0.2.42
   Compiling byteorder v1.2.3
   Compiling tiny-keccak v1.4.2
   Compiling semver v0.9.0
   Compiling fixed-hash v0.2.1 (https://github.com/niklasad1/primitives?branch=ethereum-types/no-std#a10d900f)
   Compiling ethbloom v0.5.0 (https://github.com/niklasad1/primitives?branch=ethereum-types/no-std#a10d900f)
   Compiling rustc_version v0.2.2
   Compiling uint v0.2.1 (https://github.com/niklasad1/primitives?branch=ethereum-types/no-std#a10d900f)
   Compiling ethereum-types v0.3.2 (https://github.com/niklasad1/primitives?branch=ethereum-types/no-std#a10d900f)
   Compiling no_std v0.1.0 (file:///home/niklasad1/Projects/RustExamples/no_std)
warning: unused imports: `Address`, `Public`, `Secret`, `Signature`
 --> src/main.rs:7:22
  |
7 | use ethereum_types::{Address, Public, Secret, Signature};
  |                      ^^^^^^^  ^^^^^^  ^^^^^^  ^^^^^^^^^
  |
  = note: #[warn(unused_imports)] on by default

    Finished dev [unoptimized + debuginfo] target(s) in 1m 09s

```