### PR TITLE
Bump versions of ethbloom and ethereum-types

### DIFF
--- a/ethbloom/Cargo.toml
+++ b/ethbloom/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethbloom"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Ethereum bloom filter"
 license = "MIT"

--- a/ethereum-types/Cargo.toml
+++ b/ethereum-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethereum-types"
-version = "0.3.2"
+version = "0.3.3"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 homepage = "https://github.com/paritytech/primitives"


### PR DESCRIPTION
The changes in [#42](https://github.com/paritytech/primitives/pull/42)
requires a version-bump in order to be published on https://crates.io/

Closes #35 & #36 

When this is merged publish on https://crates.io/