### PR TITLE
no_std `panic_implementation` -> `panic_handler`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,2 +1,2 @@
 [workspace]
-members = ["ethereum-types", "ethbloom"]
+members = ["ethereum-types", "ethbloom", "no-std-tests"]

--- a/no-std-tests/src/main.rs
+++ b/no-std-tests/src/main.rs
@@ -1,4 +1,4 @@
-#![feature(lang_items, start, panic_implementation)]
+#![feature(lang_items, start, panic_handler)]
 #![no_std]
 
 extern crate libc;
@@ -19,7 +19,7 @@ fn start(_argc: isize, _argv: *const *const u8) -> isize {
 pub extern "C" fn rust_eh_personality() {}
 
 #[cfg(not(test))]
-#[panic_implementation]
+#[panic_handler]
 fn panic(_info: &core::panic::PanicInfo) -> ! {
     unsafe {
         libc::abort();


### PR DESCRIPTION
```panic_implementation``` is deprecated which is now ```panic_handler```, See https://github.com/rust-lang/rust/issues/44489#issuecomment-415140224 