### PR TITLE
fix(deser): fix indexing into `str` bug

### DIFF
--- a/ethbloom/Cargo.toml
+++ b/ethbloom/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethbloom"
-version = "0.6.0"
+version = "0.6.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Ethereum bloom filter"
 license = "MIT"
@@ -18,6 +18,7 @@ serde = { version = "1.0", optional = true }
 [dev-dependencies]
 rand = { version = "0.4" }
 hex-literal = "0.1.1"
+rustc-hex = "1.0"
 
 [features]
 default = ["std", "heapsize", "serialize", "fixed-hash/libc", "fixed-hash/rustc-hex"]

--- a/ethereum-types/Cargo.toml
+++ b/ethereum-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethereum-types"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 homepage = "https://github.com/paritytech/primitives"

--- a/ethereum-types/src/uint.rs
+++ b/ethereum-types/src/uint.rs
@@ -188,6 +188,7 @@ mod tests {
 				}
 
 				// Invalid examples
+				assert!(ser::from_str::<$name>("\"∀∂\"").unwrap_err().is_data());
 				assert!(ser::from_str::<$name>("\"0x\"").unwrap_err().is_data());
 				assert!(ser::from_str::<$name>("\"0xg\"").unwrap_err().is_data());
 				assert!(ser::from_str::<$name>("\"\"").unwrap_err().is_data());

--- a/serialize/src/lib.rs
+++ b/serialize/src/lib.rs
@@ -86,8 +86,6 @@ pub fn deserialize_check_len<'a, 'de, D>(deserializer: D, len: ExpectedLen<'a>) 
 		}
 
 		fn visit_str<E: de::Error>(self, v: &str) -> Result<Self::Value, E> {
-			// TODO: replace `v.starts_with("0x")` with `v.as_bytes()[0..2] != ['0' as u8, 'x' as u8]`
-			// if `starts_with` is too slow
 			if !v.starts_with("0x") {
 				return Err(E::custom("prefix is missing"))
 			}

--- a/serialize/src/lib.rs
+++ b/serialize/src/lib.rs
@@ -86,9 +86,9 @@ pub fn deserialize_check_len<'a, 'de, D>(deserializer: D, len: ExpectedLen<'a>) 
 		}
 
 		fn visit_str<E: de::Error>(self, v: &str) -> Result<Self::Value, E> {
-			// TODO: replace `v.starts_with("0x")` with `v.as_bytes()[0..2] != ['0' as u8, 'x' as u8]
+			// TODO: replace `v.starts_with("0x")` with `v.as_bytes()[0..2] != ['0' as u8, 'x' as u8]`
 			// if `starts_with` is too slow
-			if v.len() < 2  || !v.starts_with("0x") {
+			if !v.starts_with("0x") {
 				return Err(E::custom("prefix is missing"))
 			}
 
@@ -121,7 +121,7 @@ pub fn deserialize_check_len<'a, 'de, D>(deserializer: D, len: ExpectedLen<'a>) 
 						continue
 					}
 					_ => {
-						let ch = v.bytes().skip(idx).next().unwrap();
+						let ch = v.bytes().skip(idx).next().unwrap() as char;
 						return Err(E::custom(&format!("invalid hex character: {}, at {}", ch, idx)))
 					}
 				}

--- a/serialize/src/lib.rs
+++ b/serialize/src/lib.rs
@@ -86,7 +86,9 @@ pub fn deserialize_check_len<'a, 'de, D>(deserializer: D, len: ExpectedLen<'a>) 
 		}
 
 		fn visit_str<E: de::Error>(self, v: &str) -> Result<Self::Value, E> {
-			if v.len() < 2  || &v[0..2] != "0x" {
+			// TODO: replace `v.starts_with("0x")` with `v.as_bytes()[0..2] != ['0' as u8, 'x' as u8]
+			// if `starts_with` is too slow
+			if v.len() < 2  || !v.starts_with("0x") {
 				return Err(E::custom("prefix is missing"))
 			}
 
@@ -119,7 +121,7 @@ pub fn deserialize_check_len<'a, 'de, D>(deserializer: D, len: ExpectedLen<'a>) 
 						continue
 					}
 					_ => {
-						let ch = v[idx..].chars().next().unwrap();
+						let ch = v.bytes().skip(idx).next().unwrap();
 						return Err(E::custom(&format!("invalid hex character: {}, at {}", ch, idx)))
 					}
 				}


### PR DESCRIPTION
[str](https://doc.rust-lang.org/std/primitive.str.html) consist of unicode characters which can be between 1-4 bytes long and indexing assuming that all are 1 byte may panic