### PR TITLE
fix(bump `serialize`): prep new release

### DIFF
--- a/ethbloom/Cargo.toml
+++ b/ethbloom/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethbloom"
-version = "0.6.1"
+version = "0.6.2"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Ethereum bloom filter"
 license = "MIT"
@@ -12,7 +12,7 @@ repository = "https://github.com/paritytech/primitives"
 tiny-keccak = "1.4"
 crunchy = { version = "0.2.1", default-features = false, features = ["limit_256"] }
 fixed-hash = { version = "0.3", default_features = false }
-ethereum-types-serialize = { version = "0.2.1", path = "../serialize", optional = true }
+ethereum-types-serialize = { version = "0.2.2", path = "../serialize", optional = true }
 serde = { version = "1.0", optional = true }
 
 [dev-dependencies]

--- a/ethereum-types/Cargo.toml
+++ b/ethereum-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethereum-types"
-version = "0.5.1"
+version = "0.5.2"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 homepage = "https://github.com/paritytech/primitives"
@@ -9,7 +9,7 @@ description = "Ethereum types"
 [dependencies]
 crunchy = { version = "0.2.1", default-features = false }
 ethbloom = { path = "../ethbloom", version = "0.6", default-features = false }
-ethereum-types-serialize = { version = "0.2.1", path = "../serialize", optional = true }
+ethereum-types-serialize = { version = "0.2.2", path = "../serialize", optional = true }
 fixed-hash = { version = "0.3", default_features = false }
 serde = { version = "1.0", optional = true }
 uint = { version = "0.5", default_features = false }

--- a/serialize/Cargo.toml
+++ b/serialize/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethereum-types-serialize"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT"
 homepage = "https://github.com/paritytech/primitives"


### PR DESCRIPTION
The reason for bumping was to include #62 however I manage to forget it!

I will `yank` the versions `0.4.1` and `0.5.1` after this is merged!